### PR TITLE
Updated sub module links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "shared"]
 	path = shared
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_American/shared.git
+	url = ../American-WTMP-5Q.git
 [submodule "rss"]
 	path = rss
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_American/rss.git
+	url = ../American-WTMP-RSS.git
 [submodule "reports"]
 	path = reports
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_American/reports.git
+	url = ../WTMP-American-Reports.git
 [submodule "ras"]
 	path = ras
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_American/ras.git
+	url = ../American-WTMP-RAS.git
 [submodule "cequal-w2"]
 	path = cequal-w2
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_American/cequal-w2.git
+	url = ../American-WTMP-CEQUAL-W2.git
 [submodule "5q"]
 	path = 5q
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_American/5q.git
+	url = ../American-WTMP-5Q.git
 [submodule "scripts"]
 	path = scripts
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_American/scripts.git
+	url = ../American-WTMP-Scripts.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "shared"]
 	path = shared
-	url = ../American-WTMP-5Q.git
+	url = git@github.com:DOI-BOR/American-WTMP-5Q.git
 [submodule "rss"]
 	path = rss
-	url = ../American-WTMP-RSS.git
+	url = git@github.com:DOI-BOR/American-WTMP-RSS.git
 [submodule "reports"]
 	path = reports
-	url = ../WTMP-American-Reports.git
+	url = git@github.com:DOI-BOR/WTMP-American-Reports.git
 [submodule "ras"]
 	path = ras
-	url = ../American-WTMP-RAS.git
+	url = git@github.com:DOI-BOR/American-WTMP-RAS.git
 [submodule "cequal-w2"]
 	path = cequal-w2
-	url = ../American-WTMP-CEQUAL-W2.git
+	url = git@github.com:DOI-BOR/American-WTMP-CEQUAL-W2.git
 [submodule "5q"]
 	path = 5q
-	url = ../American-WTMP-5Q.git
+	url = git@github.com:DOI-BOR/American-WTMP-5Q.git
 [submodule "scripts"]
 	path = scripts
-	url = ../American-WTMP-Scripts.git
+	url = git@github.com:DOI-BOR/American-WTMP-Scripts.git


### PR DESCRIPTION
Previously the submodels were linked the RMA's GitLab. Now they point to the corresponding Reclamation GitHub repositories. The links are the SSH urls.