### PR TITLE
Updated submodules links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "shared"]
 	path = shared
-	url = git@github.com:DOI-BOR/American-WTMP-5Q.git
+	url = git@github.com:DOI-BOR/American-WTMP-Shared.git
 [submodule "rss"]
 	path = rss
 	url = git@github.com:DOI-BOR/American-WTMP-RSS.git
 [submodule "reports"]
 	path = reports
-	url = git@github.com:DOI-BOR/WTMP-American-Reports.git
+	url = git@github.com:DOI-BOR/American-WTMP-Reports.git
 [submodule "ras"]
 	path = ras
 	url = git@github.com:DOI-BOR/American-WTMP-RAS.git


### PR DESCRIPTION
Two submodule links are updated here. Previously the shared folder was accidently pointing to the 5Q repository and now that has been corrected. The reports repository used to have a different naming order and now that has been updated. The two updates allow for pulling down the submodules to work.

I have tested pulling down the submodules with this set up and it works.