### PR TITLE
Fix broken simulations

### DIFF
--- a/wat/modelLinking/W2_Fol-Nat.linkages
+++ b/wat/modelLinking/W2_Fol-Nat.linkages
@@ -141,7 +141,7 @@
         <DataLocation Name="WB 1 Met" Class="hec2.model.DataLocation" DssPath="/W2:met.npt/WB 1 Met/PHI//1HOUR/alt:ap:CeQualW2-WB 1 Met/" ComputeType="Computed" Model="DSS File" Parameter="PHI" OutOfDate="false" PrevModelIndex="0">
           <ModelAlternative Name="W2 Natoma Prescribed" Program="CeQualW2" />
           <DownStreamLocation>
-            <DataLocation Name="FAIR OAKS" Class="hec2.model.DssDataLocation" DssPath="/MR AM.-NATOMA LAKE/FAIR OAKS/DIR-WIND-RADIANS//1Hour/251.40.133.1.2/" ComputeType="Computed" Parameter="DIR-WIND-RADIANS" OutOfDate="false" PrevModelIndex="0">
+            <DataLocation Name="Fair Oaks" Class="hec2.model.DssDataLocation" DssPath="/MR Am.-Natoma Lake/Fair Oaks/Dir-Wind//1Hour/251.40.133.1.2/" ComputeType="Computed" Parameter="Dir-Wind" OutOfDate="false" PrevModelIndex="0">
               <DssFile>shared/WTMP_American_Forecast.dss</DssFile>
             </DataLocation>
           </DownStreamLocation>

--- a/wat/modelLinking/W2_Fol-Nat_NoBypass.linkages
+++ b/wat/modelLinking/W2_Fol-Nat_NoBypass.linkages
@@ -53,7 +53,7 @@
         <DataLocation Name="Branch 1 Inflow" Class="hec2.model.DataLocation" DssPath="/W2:tin_br1.npt/Branch 1 Inflow/Temp-TIN//1HOUR/alt:ap:CeQualW2-Branch 1 Inflow/" ComputeType="Computed" Model="Scripting-OutputLink_W2_FBYPASS-DownstreamAmer" Parameter="Temp-TIN" OutOfDate="false" PrevModelIndex="0">
           <ModelAlternative Name="W2 Natoma Prescribed" Program="CeQualW2" />
           <DownStreamLocation>
-            <DataLocation Name="W2_Natoma_InflowQ" Class="hec2.model.DataLocation" DssPath="//W2_Natoma_InflowQ/Flow//1HOUR/C:000000|altName:apName:Scripting-OutputLink_W2_FBYPASS-/" ComputeType="Computed" Parameter="Flow" OutOfDate="false" PrevModelIndex="0">
+            <DataLocation Name="W2_Natoma_InflowT" Class="hec2.model.DataLocation" DssPath="//W2_Natoma_InflowT/Temp-Water//1HOUR/C:000000|altName:apName:Scripting-OutputLink_W2_FBYPASS-/" ComputeType="Computed" Parameter="Temp-Water" OutOfDate="false" PrevModelIndex="0">
               <ModelAlternative Name="OutputLink_W2_FBYPASS-DownstreamAmer" Program="Scripting" />
             </DataLocation>
           </DownStreamLocation>

--- a/wat/modelLinking/W2_Folsom_NRV_FixedATSP_NoBypass.linkages
+++ b/wat/modelLinking/W2_Folsom_NRV_FixedATSP_NoBypass.linkages
@@ -599,11 +599,11 @@
             </DataLocation>
           </DownStreamLocation>
         </DataLocation>
-        <DataLocation Name="WQ-Folsom Dam - Natoma balance flows" Class="hec2.model.DataLocation" Description="" DssPath="/MR Am.-Folsom Lake/FOL-Penstock WTemp 1/Temp-Water//1Hour/250.3.50.1.1/" ComputeType="Computed" Model="Scripting-OutputLink_W2_Folsom-DownstreamAmer" Parameter="Water Temperature" OutOfDate="false" PrevModelIndex="0">
+        <DataLocation Name="WQ-Folsom Dam - Natoma balance flows" Class="hec2.model.DataLocation" Description="" DssPath="/MR Am.-Folsom Lake/FOL-Penstock WTemp 1/Temp-Water//1Hour/250.3.50.1.1/" ComputeType="Computed" Model="Scripting-OutputLink_W2_FATSPBYPASS-DownstreamAmer" Parameter="Water Temperature" OutOfDate="false" PrevModelIndex="0">
           <ModelAlternative Name="RSAmerNRV" Program="ResSim" />
           <DownStreamLocation>
-            <DataLocation Name="W2_Natoma_InflowT" Class="hec2.model.DataLocation" DssPath="//W2_Natoma_InflowT/Temp-Water//1HOUR/C:000000|altName:apName:Scripting-OutputLink_W2_Folsom-D/" ComputeType="Computed" Parameter="Temp-Water" OutOfDate="false" PrevModelIndex="0">
-              <ModelAlternative Name="OutputLink_W2_Folsom-DownstreamAmer" Program="Scripting" />
+            <DataLocation Name="W2_Natoma_InflowT" Class="hec2.model.DataLocation" DssPath="//W2_Natoma_InflowT/Temp-Water//1HOUR/C:000000|altName:apName:Scripting-OutputLink_W2_FATSPBYP/" ComputeType="Computed" Parameter="Temp-Water" OutOfDate="false" PrevModelIndex="0">
+              <ModelAlternative Name="OutputLink_W2_FATSPBYPASS-DownstreamAmer" Program="Scripting" />
             </DataLocation>
           </DownStreamLocation>
         </DataLocation>

--- a/wat/modelLinking/W2_Natoma_Test.linkages
+++ b/wat/modelLinking/W2_Natoma_Test.linkages
@@ -104,7 +104,7 @@
         <DataLocation Name="WB 1 Met" Class="hec2.model.DataLocation" DssPath="/W2:met.npt/WB 1 Met/PHI//1HOUR/alt:ap:CeQualW2-WB 1 Met/" ComputeType="Computed" Model="DSS File" Parameter="PHI" OutOfDate="false" PrevModelIndex="0">
           <ModelAlternative Name="W2 Natoma Prescribed" Program="CeQualW2" />
           <DownStreamLocation>
-            <DataLocation Name="FAIR OAKS" Class="hec2.model.DssDataLocation" DssPath="/MR AM.-NATOMA LAKE/FAIR OAKS/DIR-WIND-RADIANS//1Hour/251.40.133.1.2/" ComputeType="Computed" Parameter="DIR-WIND-RADIANS" OutOfDate="false" PrevModelIndex="0">
+            <DataLocation Name="Fair Oaks" Class="hec2.model.DssDataLocation" DssPath="/MR Am.-Natoma Lake/Fair Oaks/Dir-Wind//1Hour/251.40.133.1.2/" ComputeType="Computed" Parameter="Dir-Wind" OutOfDate="false" PrevModelIndex="0">
               <DssFile>shared/WTMP_American_Forecast.dss</DssFile>
             </DataLocation>
           </DownStreamLocation>


### PR DESCRIPTION
Fixes #25 fixes #26 fixes #27 

Three American forecast simulations were found to not work when testing the American studies. These changes bring them back to working order. 

W2 Fol-Nat: Fair Oaks wind direction path needed an update in the linkages
W2 Fol-Nat No Bypass: Natoma inflow temp was pulling inflow amount. Fixed linkage.
W2 Folsom NRV Fixed ATSP No Bypass: Two linkages were trying to pull from the wrong preprocessing script output. Now updated in the linkages

W2 Natoma Prescribed: Unclear on if this simulation even works but the issue with W2 Fol-Nat also affected this so that has been updated. Further testing will be needed to make sure everything else works.

Tested W2 Fol-Nat, W2 Fol-Nat No Bypass, and W2 Folsom NRV Fixed ATSP No Bypass and they are working.